### PR TITLE
Remove several implicit function declarations

### DIFF
--- a/src/lib/libsolcompat/include/sys/time.h
+++ b/src/lib/libsolcompat/include/sys/time.h
@@ -59,7 +59,7 @@ static inline hrtime_t gethrtime(void) {
 		fprintf(stderr, "Error: clock_gettime(CLOCK_MONOTONIC) failed\n");
 		fprintf(stderr, "Make sure you are are running kernel 2.6.x and have glibc 2.3.3 or newer installed\n");
 		fprintf(stderr, "Aborting...\n");
-		abort();
+		__builtin_abort();
 	}
 
 	return (((u_int64_t)ts.tv_sec) * NANOSEC) + ts.tv_nsec;

--- a/src/lib/libumem/configure
+++ b/src/lib/libumem/configure
@@ -4231,8 +4231,8 @@ main ()
   for (i = 0; i < 256; i++)
     if (XOR (islower (i), ISLOWER (i))
 	|| toupper (i) != TOUPPER (i))
-      exit(2);
-  exit (0);
+      return 2;
+  return 0;
 }
 _ACEOF
 rm -f conftest$ac_exeext

--- a/src/lib/libumem/malloc.c
+++ b/src/lib/libumem/malloc.c
@@ -38,6 +38,7 @@
 #endif
 
 #include "umem_base.h"
+#include <umem_impl.h>
 
 #include "misc.h"
 

--- a/src/lib/libumem/umem_fail.c
+++ b/src/lib/libumem/umem_fail.c
@@ -33,6 +33,7 @@
  * Failure routines for libumem (not standalone)
  */
 
+#define _GNU_SOURCE
 #include "config.h"
 #include <sys/types.h>
 #include <signal.h>

--- a/src/lib/libumem/umem_impl.h
+++ b/src/lib/libumem/umem_impl.h
@@ -412,10 +412,8 @@ typedef struct umem_cpu {
 #define	UMEM_READY_INITING		2
 #define	UMEM_READY			3
 
-#ifdef UMEM_STANDALONE
 extern void umem_startup(caddr_t, size_t, size_t, caddr_t, caddr_t);
 extern int umem_add(caddr_t, size_t);
-#endif
 
 #ifdef	__cplusplus
 }

--- a/src/lib/libumem/umem_test.c
+++ b/src/lib/libumem/umem_test.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "umem.h"
+#include <umem_impl.h>
 
 int main(int argc, char *argv[])
 {

--- a/src/lib/libumem/umem_test2.c
+++ b/src/lib/libumem/umem_test2.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "umem.h"
+#include <umem_impl.h>
 
 static const char *TESTSTRINGS[] = {
   "fred",


### PR DESCRIPTION
Avoid implicit declarations of exit, sigrelse, abort and umem_startup. This ensures that zfs-fuse continues to build when a compiler does not support implicit function declarations by default (C99).

The change to src/lib/libsolcompat/include/sys/time.h is a hack to work around a circular dependency between the libsolcompat sys/time.h and sys/types.h includes that eventually leads to abort being used before it is defined by stdlib.h.

Related to:

  https://fedoraproject.org/wiki/Changes/PortingToModernC
  https://fedoraproject.org/wiki/Toolchain/PortingToModernC